### PR TITLE
Corvid testkit local site

### DIFF
--- a/packages/corvid-local-server/src/socket-api/editorSocketHandler.js
+++ b/packages/corvid-local-server/src/socket-api/editorSocketHandler.js
@@ -12,11 +12,15 @@ const initEditorApi = editorApi => ({
 
 const socketHandler = editorApi => {
   let currentSocket;
-  editorApi.onCodeChanged(localCodePayload =>
-    currentSocket.emit("LOCAL_CODE_UPDATED", localCodePayload)
-  );
+  editorApi.onCodeChanged(localCodePayload => {
+    if (editorApi.isEditorConnected()) {
+      currentSocket.emit("LOCAL_CODE_UPDATED", localCodePayload);
+    }
+  });
   editorApi.onDocumentChanged(() => {
-    currentSocket.emit("LOCAL_DOCUMENT_UPDATED");
+    if (editorApi.isEditorConnected()) {
+      currentSocket.emit("LOCAL_DOCUMENT_UPDATED");
+    }
   });
   return socket => {
     currentSocket = socket;

--- a/packages/corvid-local-server/test/it/admin-api.spec.js
+++ b/packages/corvid-local-server/test/it/admin-api.spec.js
@@ -6,7 +6,9 @@ const {
   localServer,
   closeAll
 } = require("../utils/autoClosing");
-const { initLocalSite } = require("../utils/localSiteDir");
+const {
+  localSiteDir: { initLocalSite }
+} = require("corvid-local-test-utils");
 
 afterEach(closeAll);
 

--- a/packages/corvid-local-server/test/it/admin-connections.spec.js
+++ b/packages/corvid-local-server/test/it/admin-connections.spec.js
@@ -4,7 +4,9 @@ const {
   localServer,
   closeAll
 } = require("../utils/autoClosing");
-const { initLocalSite } = require("../utils/localSiteDir");
+const {
+  localSiteDir: { initLocalSite }
+} = require("corvid-local-test-utils");
 
 afterEach(closeAll);
 

--- a/packages/corvid-local-server/test/it/backup.spec.js
+++ b/packages/corvid-local-server/test/it/backup.spec.js
@@ -7,7 +7,7 @@ const {
   localServer,
   closeAll
 } = require("../utils/autoClosing");
-const localSiteDir = require("../utils/localSiteDir");
+const { localSiteDir } = require("corvid-local-test-utils");
 const merge_ = require("lodash/merge");
 const fs = require("fs-extra");
 const path = require("path");

--- a/packages/corvid-local-server/test/it/cloneMode.spec.js
+++ b/packages/corvid-local-server/test/it/cloneMode.spec.js
@@ -7,10 +7,8 @@ const {
   closeAll
 } = require("../utils/autoClosing");
 const {
-  initLocalSite,
-  readLocalSite,
-  doesExist: doesLocalFileExist
-} = require("../utils/localSiteDir");
+  localSiteDir: { initLocalSite, readLocalSite, doesExist: doesLocalFileExist }
+} = require("corvid-local-test-utils");
 
 afterEach(closeAll);
 

--- a/packages/corvid-local-server/test/it/editMode.spec.js
+++ b/packages/corvid-local-server/test/it/editMode.spec.js
@@ -7,7 +7,7 @@ const {
   localServer,
   closeAll
 } = require("../utils/autoClosing");
-const localSiteDir = require("../utils/localSiteDir");
+const { localSiteDir } = require("corvid-local-test-utils");
 
 afterEach(closeAll);
 

--- a/packages/corvid-local-server/test/it/editor-connections.spec.js
+++ b/packages/corvid-local-server/test/it/editor-connections.spec.js
@@ -4,7 +4,9 @@ const {
   localServer,
   closeAll
 } = require("../utils/autoClosing");
-const { initLocalSite } = require("../utils/localSiteDir");
+const {
+  localSiteDir: { initLocalSite }
+} = require("corvid-local-test-utils");
 
 afterEach(closeAll);
 

--- a/packages/corvid-local-server/test/it/error-reporting.spec.js
+++ b/packages/corvid-local-server/test/it/error-reporting.spec.js
@@ -12,7 +12,7 @@ const {
   localServer,
   closeAll
 } = require("../utils/autoClosing");
-const { initLocalSite } = require("../utils/localSiteDir");
+
 const { editorSiteBuilder } = require("corvid-fake-local-mode-editor");
 const { localSiteBuilder } = require("corvid-local-site/testkit");
 
@@ -32,7 +32,7 @@ describe("santy tests for error reporting", () => {
   });
 
   it("should report clone errors to sentry", async () => {
-    const localSitePath = await initLocalSite();
+    const localSitePath = await testUtils.localSiteDir.initLocalSite();
     const server = await localServer.startInCloneMode(localSitePath);
 
     const editorSite = editorSiteBuilder.buildFull();
@@ -50,7 +50,7 @@ describe("santy tests for error reporting", () => {
   });
 
   it("should report save errors to sentry", async () => {
-    const localSitePath = await initLocalSite();
+    const localSitePath = await testUtils.localSiteDir.initLocalSite();
     const server = await localServer.startInCloneMode(localSitePath);
 
     const editorSite = editorSiteBuilder.buildFull();
@@ -73,7 +73,9 @@ describe("santy tests for error reporting", () => {
   if (!isWindows) {
     it("should report errors loading in edit mode", async () => {
       const localSite = localSiteBuilder.buildFull();
-      const localSitePath = await initLocalSite(localSite);
+      const localSitePath = await testUtils.localSiteDir.initLocalSite(
+        localSite
+      );
 
       await fs.chmod(localSitePath, fs.constants.S_IWUSR); // owner can only write
       await localServer.startInEditMode(localSitePath).catch(() => {});

--- a/packages/corvid-local-server/test/it/handshake.spec.js
+++ b/packages/corvid-local-server/test/it/handshake.spec.js
@@ -1,6 +1,8 @@
 const { socketClient } = require("corvid-local-test-utils");
 const { localServer, closeAll } = require("../utils/autoClosing");
-const { initLocalSite } = require("../utils/localSiteDir");
+const {
+  localSiteDir: { initLocalSite }
+} = require("corvid-local-test-utils");
 
 const { version: localServerModuleVersion } = require("../../package.json");
 

--- a/packages/corvid-local-server/test/it/localCodeChanges.spec.js
+++ b/packages/corvid-local-server/test/it/localCodeChanges.spec.js
@@ -9,10 +9,8 @@ const {
   closeAll
 } = require("../utils/autoClosing");
 const {
-  initLocalSite,
-  writeFile,
-  deleteFile
-} = require("../utils/localSiteDir");
+  localSiteDir: { initLocalSite, writeFile, deleteFile }
+} = require("corvid-local-test-utils");
 
 const codeItemsTypes = Object.keys(sc.codeCreators);
 

--- a/packages/corvid-local-server/test/it/localDocumentChanges.spec.js
+++ b/packages/corvid-local-server/test/it/localDocumentChanges.spec.js
@@ -8,10 +8,8 @@ const {
   closeAll
 } = require("../utils/autoClosing");
 const {
-  initLocalSite,
-  writeFile,
-  deleteFile
-} = require("../utils/localSiteDir");
+  localSiteDir: { initLocalSite, writeFile, deleteFile }
+} = require("corvid-local-test-utils");
 
 const documentCreatorsTypes = Object.keys(sc.documentCreators);
 

--- a/packages/corvid-local-server/test/it/pageFiles.spec.js
+++ b/packages/corvid-local-server/test/it/pageFiles.spec.js
@@ -8,10 +8,12 @@ const {
   closeAll
 } = require("../utils/autoClosing");
 const {
-  initLocalSite,
-  readFile: readSiteFile,
-  doesExist: doesSiteFileExist
-} = require("../utils/localSiteDir");
+  localSiteDir: {
+    initLocalSite,
+    readFile: readSiteFile,
+    doesExist: doesSiteFileExist
+  }
+} = require("corvid-local-test-utils");
 
 afterEach(closeAll);
 

--- a/packages/corvid-local-server/test/it/pullMode.spec.js
+++ b/packages/corvid-local-server/test/it/pullMode.spec.js
@@ -7,7 +7,9 @@ const {
   localServer,
   closeAll
 } = require("../utils/autoClosing");
-const { initLocalSite, readLocalSite } = require("../utils/localSiteDir");
+const {
+  localSiteDir: { initLocalSite, readLocalSite }
+} = require("corvid-local-test-utils");
 const { readDirToJson } = require("corvid-dir-as-json");
 
 const now = Date.now();

--- a/packages/corvid-local-server/test/it/security.spec.js
+++ b/packages/corvid-local-server/test/it/security.spec.js
@@ -1,6 +1,8 @@
 const { socketClient, initTempDir } = require("corvid-local-test-utils");
 const { localServer, closeAll } = require("../utils/autoClosing");
-const { initLocalSite, readLocalSite } = require("../utils/localSiteDir");
+const {
+  localSiteDir: { initLocalSite, readLocalSite }
+} = require("corvid-local-test-utils");
 
 const fs = require("fs-extra");
 const path = require("path");

--- a/packages/corvid-local-test-utils/package.json
+++ b/packages/corvid-local-test-utils/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "corvid-dir-as-json": "0.1.77",
+    "fs-extra": "^8.1.0",
     "lodash": "^4.17.11",
     "socket.io-client": "^2.2.0",
     "temp": "^0.9.0"

--- a/packages/corvid-local-test-utils/src/index.js
+++ b/packages/corvid-local-test-utils/src/index.js
@@ -4,10 +4,11 @@ const withClose = require("./withClose");
 const initTempDir = require("./initTempDir");
 const sentryTestkit = require("./sentry/sentryTestkit");
 const overrideEnv = require("./overrideEnv");
-
+const localSiteDir = require("./localSiteDir");
 module.exports = {
   siteCreators,
   socketClient,
+  localSiteDir,
   withClose,
   initTempDir,
   sentryTestkit,

--- a/packages/corvid-local-test-utils/src/localSiteDir.js
+++ b/packages/corvid-local-test-utils/src/localSiteDir.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const fs = require("fs-extra");
 const dirAsJson = require("corvid-dir-as-json");
-const { initTempDir } = require("corvid-local-test-utils");
+const initTempDir = require("./initTempDir");
 
 const siteSrcPath = rootPath => path.join(rootPath, "src");
 
@@ -38,6 +38,8 @@ const initLocalSite = async (localSiteFiles, createdRoodDir) => {
   return rootDir;
 };
 
+const cleanLocalSite = async rootPath => fs.remove(rootPath);
+
 const initBackup = (rootPath, localSiteFiles) =>
   dirAsJson.writeJsonToDir(
     path.join(rootPath, ".corvid", "backup"),
@@ -46,6 +48,7 @@ const initBackup = (rootPath, localSiteFiles) =>
 
 module.exports = {
   doesExist,
+  cleanLocalSite,
   initLocalSite,
   readLocalSite,
   writeFile,

--- a/packages/corvid-local-testkit/README.md
+++ b/packages/corvid-local-testkit/README.md
@@ -1,1 +1,24 @@
-#
+# Corvid Local Testkit
+ This test kit exposes the localMode express server and drivers to the local file system
+
+### Example
+Clone Mode:
+```
+const {server, localSite} = require('corvid-local-testkit')
+
+const cloneLocalSiteDriver = await localSite.init()
+const cloneLocalServerDriver = await server.startInCloneMode(localSiteDriver)
+
+```
+Edit Mode:
+```
+const {server, localSite} = require('corvid-local-testkit')
+
+/*
+* first you need to get valid local files (clone command)
+*/
+const localFiles = await cloneLocalSiteDriver.getFiles()
+
+const editLocalSiteDriver = await localSite.init(localFiles)
+const editLocalServerDriver = await server.startInEditMode(localSiteDriver)
+```

--- a/packages/corvid-local-testkit/README.md
+++ b/packages/corvid-local-testkit/README.md
@@ -7,7 +7,7 @@ Clone Mode:
 const {server, localSite} = require('corvid-local-testkit')
 
 const cloneLocalSiteDriver = await localSite.init()
-const cloneLocalServerDriver = await server.startInCloneMode(localSiteDriver)
+const cloneLocalServerDriver = await server.startInCloneMode(cloneLocalSiteDriver)
 
 ```
 Edit Mode:
@@ -17,8 +17,13 @@ const {server, localSite} = require('corvid-local-testkit')
 /*
 * first you need to get valid local files (clone command)
 */
+
+const cloneLocalSiteDriver = await localSite.init()
+const cloneLocalServerDriver = await server.startInCloneMode(cloneLocalSiteDriver)
+
+
 const localFiles = await cloneLocalSiteDriver.getFiles()
 
 const editLocalSiteDriver = await localSite.init(localFiles)
-const editLocalServerDriver = await server.startInEditMode(localSiteDriver)
+const editLocalServerDriver = await server.startInEditMode(editLocalSiteDriver)
 ```

--- a/packages/corvid-local-testkit/src/index.js
+++ b/packages/corvid-local-testkit/src/index.js
@@ -30,9 +30,7 @@ const localSite = {
   }
 };
 
-const localTestkit = {
+module.exports = {
   localSite,
   server
 };
-
-module.exports = localTestkit;

--- a/packages/corvid-local-testkit/src/index.js
+++ b/packages/corvid-local-testkit/src/index.js
@@ -1,33 +1,37 @@
 "use strict";
+const { localSiteDir } = require("corvid-local-test-utils");
+const corvidLocalServerTestkit = require("corvid-local-server/src/testkit");
 
-var fs = require("fs");
-var path = require("path");
+const LOCAL_SITE_PATH = Symbol.for("local-site-path");
 
-var { initTempDir } = require("corvid-local-test-utils");
-var corvidLocalServerTestkit = require("corvid-local-server/src/testkit");
-
-function initSite(siteItems) {
-  return initTempDir(siteItems).then(function(localSite) {
-    fs.writeFileSync(
-      path.join(localSite, ".corvid", "corvidrc.json"),
-      "",
-      "utf8"
-    );
-    return Promise.resolve(localSite);
-  });
-}
-
-var server = {
-  startInEditMode: function(siteItems) {
-    return corvidLocalServerTestkit.startInEditMode(siteItems);
+const server = {
+  startInEditMode: function(localSite) {
+    return corvidLocalServerTestkit.startInEditMode(localSite[LOCAL_SITE_PATH]);
   },
-  startInCloneMode: function(siteItems) {
-    return corvidLocalServerTestkit.startInCloneMode(siteItems);
+  startInCloneMode: function(localSite) {
+    return corvidLocalServerTestkit.startInCloneMode(
+      localSite[LOCAL_SITE_PATH]
+    );
   }
 };
 
-var localTestkit = {
-  initSite,
+const localSite = {
+  init: async files => {
+    const tempDir = await localSiteDir.initLocalSite(files);
+    return {
+      [LOCAL_SITE_PATH]: tempDir,
+      getFiles: () => localSiteDir.readLocalSite(tempDir),
+      readFile: filePath => localSiteDir.readFile(tempDir, filePath),
+      writeFile: (filePath, content) =>
+        localSiteDir.writeFile(tempDir, filePath, content),
+      deleteFile: filePath => localSiteDir.deleteFile(tempDir, filePath),
+      clean: () => localSiteDir.cleanLocalSite(tempDir)
+    };
+  }
+};
+
+const localTestkit = {
+  localSite,
   server
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,6 +3551,15 @@ fs-extra@^8.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.6.tgz#2c5cc30ded81282bfe8a0d7c7c1853ddeb102c07"
@@ -3813,6 +3822,11 @@ got@^9.6.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+
+graceful-fs@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
+  integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
I am not sure how to test the fix I did to the editorSocketHandler.
Previous satiation was that if a local change was made before  editor socket was connected (maybe even during reconnecting socket), caused the server to crash (as a side effect when trying to emit when there is no socket). 

I added a check that the editor is connected before emitting an event.
Because the fact that the server was crashing I don’t know how should I test it..

I thought of doing something like: 

`

it('should not crash when a local change made before editor connects', async () => {
	
	const publicCode = sc.publicCode();
	
	const localSiteFiles = localSiteBuilder.buildFull(publicCode);
	
	const localSitePath = await localSiteDir.initLocalSite(localSiteFiles);
	
	const server = await localServer.startInEditMode(localSitePath);
	
	await localSiteDir.writeFile(
		localSiteFiles,
		localSiteBuilder.getLocalFilePath(publicCode),
		localSiteBuilder.getLocalFileContent(publicCode),
	);

	await new Promise(resolve => setTimeout(resolve, 5000));

	// without my change the test would break before sleep ends
	// if broken then should not be here

	expect(1).toEqual(1);
});
`

But I feel that this test is quite weak test, and a bit stupid ;) 
Would appreciate your inputs