### PR TITLE
corvid-cli refactor: separate modules that run in electron from node

### DIFF
--- a/packages/corvid-cli/src/commands/login.js
+++ b/packages/corvid-cli/src/commands/login.js
@@ -1,8 +1,6 @@
-/* eslint-disable no-console */
+const path = require("path");
 const chalk = require("chalk");
 const jwt = require("jsonwebtoken");
-const { URL } = require("url");
-const { app, BrowserWindow } = require("electron");
 const _ = require("lodash");
 const { launch } = require("../utils/electron");
 const createSpinner = require("../utils/spinner");
@@ -10,45 +8,6 @@ const sessionData = require("../utils/sessionData");
 const getMessage = require("../messages");
 const { UserError } = require("corvid-local-logger");
 const commandWithDefaults = require("../utils/commandWithDefaults");
-
-const mySitesUrl = "https://www.wix.com/account/sites";
-const signInHostname = "users.wix.com";
-
-app &&
-  app.on("ready", async () => {
-    const win = new BrowserWindow({
-      width: 1280,
-      height: 960,
-      show: false,
-      webPreferences: { nodeIntegration: false }
-    });
-
-    win.webContents.on("did-navigate", (event, url) => {
-      const parsed = new URL(url);
-      if (parsed.hostname === signInHostname) {
-        console.log(JSON.stringify({ event: "authenticatingUser" }));
-        win.show();
-      } else if (url === mySitesUrl) {
-        console.log(JSON.stringify({ event: "userAuthenticated" }));
-        win.hide();
-
-        win.webContents.session.cookies.get(
-          { url: "http://wix.com", name: "wixSession2" },
-          (error, cookies) => {
-            if (error) {
-              throw error;
-            }
-
-            console.log(
-              JSON.stringify({ msg: "authCookie", cookie: cookies[0] }, null, 2)
-            );
-          }
-        );
-        win.webContents.on("did-finish-load", () => app.quit());
-      }
-    });
-    win.loadURL(mySitesUrl);
-  });
 
 function parseSessionCookie(cookie) {
   try {
@@ -68,7 +27,7 @@ async function loginCommand(spinner, args = {}) {
   spinner.start(chalk.grey(getMessage("Login_Command_Accessing")));
 
   return launch(
-    __filename,
+    path.join(__dirname, "../electron/login"),
     {},
     {
       authenticatingUser: () => {

--- a/packages/corvid-cli/src/commands/logout.js
+++ b/packages/corvid-cli/src/commands/logout.js
@@ -1,27 +1,9 @@
-/* eslint-disable no-console */
+const path = require("path");
 const chalk = require("chalk");
-const { app, BrowserWindow } = require("electron");
 const { launch } = require("../utils/electron");
 const createSpinner = require("../utils/spinner");
 const getMessage = require("../messages");
 const commandWithDefaults = require("../utils/commandWithDefaults");
-
-app &&
-  app.on("ready", async () => {
-    const win = new BrowserWindow({
-      width: 1280,
-      height: 960,
-      show: false,
-      webPreferences: { nodeIntegration: false }
-    });
-    await new Promise(resolve => {
-      win.webContents.session.clearStorageData(() => {
-        resolve();
-      });
-    });
-
-    win.close();
-  });
 
 module.exports = commandWithDefaults({
   command: "logout",
@@ -30,7 +12,7 @@ module.exports = commandWithDefaults({
     const spinner = createSpinner();
     spinner.start(chalk.grey(getMessage("Logout_Command_Clearing")));
 
-    return launch(__filename).then(() => {
+    return launch(path.join(__dirname, "../electron/logout")).then(() => {
       spinner.succeed(chalk.grey(getMessage("Logout_Command_Cleared")));
     });
   }

--- a/packages/corvid-cli/src/commands/open-editor.js
+++ b/packages/corvid-cli/src/commands/open-editor.js
@@ -1,16 +1,9 @@
-/* eslint-disable no-console */
 const fs = require("fs-extra");
 const path = require("path");
 const process = require("process");
 const chalk = require("chalk");
-const { app } = require("electron");
-const {
-  openWindow,
-  launch,
-  killAllChildProcesses
-} = require("../utils/electron");
+const { launch, killAllChildProcesses } = require("../utils/electron");
 const createSpinner = require("../utils/spinner");
-const openEditorApp = require("../apps/open-editor");
 const sessionData = require("../utils/sessionData");
 const { sendOpenEditorEvent } = require("../utils/bi");
 const { readCorvidConfig } = require("../utils/corvid-config");
@@ -20,25 +13,6 @@ const commandWithDefaults = require("../utils/commandWithDefaults");
 const {
   versions: { readFileSystemLayoutVersion }
 } = require("corvid-local-site");
-
-app &&
-  app.on("ready", async () => {
-    if (process.env.IGNORE_CERTIFICATE_ERRORS) {
-      app.on(
-        "certificate-error",
-        (event, webContents, url, error, certificate, callback) => {
-          // On certificate error we disable default behaviour (stop loading the page)
-          // and we then say "it is all fine - true" to the callback
-          event.preventDefault();
-          callback(true);
-        }
-      );
-    }
-
-    await openWindow(openEditorApp(), {
-      show: true && !process.env.CORVID_FORCE_HEADLESS
-    });
-  });
 
 const ensureLocalFileSystemVersion = async siteRootPath => {
   const existingFileSystemLayoutVersion = await readFileSystemLayoutVersion(
@@ -86,7 +60,7 @@ async function openEditorHandler(args) {
     process.on("exit", () => killAllChildProcesses());
 
     launch(
-      __filename,
+      path.join(__dirname, "../electron/open-editor"),
       {
         // TODO uncomment the following two option to spawn the app in the
         // background once the local server can be spawned in the background as

--- a/packages/corvid-cli/src/commands/pull.js
+++ b/packages/corvid-cli/src/commands/pull.js
@@ -2,10 +2,7 @@
 const path = require("path");
 const process = require("process");
 const chalk = require("chalk");
-const { app } = require("electron");
-const yargs = require("yargs");
-const { openWindow, launch } = require("../utils/electron");
-const pullApp = require("../apps/pull");
+const { launch } = require("../utils/electron");
 const createSpinner = require("../utils/spinner");
 const sessionData = require("../utils/sessionData");
 const { sendPullEvent } = require("../utils/bi");
@@ -14,34 +11,15 @@ const getMessage = require("../messages");
 const { UserError } = require("corvid-local-logger");
 const commandWithDefaults = require("../utils/commandWithDefaults");
 
-app &&
-  app.on("ready", async () => {
-    if (process.env.IGNORE_CERTIFICATE_ERRORS) {
-      app.on(
-        "certificate-error",
-        (event, webContents, url, error, certificate, callback) => {
-          // On certificate error we disable default behaviour (stop loading the page)
-          // and we then say "it is all fine - true" to the callback
-          event.preventDefault();
-          callback(true);
-        }
-      );
-    }
-
-    const args = yargs.argv;
-    await openWindow(pullApp({ override: args.override, move: args.move }));
-  });
-
 async function pullCommand(spinner, args) {
   spinner.start(chalk.grey(getMessage("Pull_Command_Connecting")));
   const pullArgs = [];
 
   if (args.override) pullArgs.push("--override");
   if (args.move) pullArgs.push("--move");
-
   await new Promise((resolve, reject) => {
     launch(
-      __filename,
+      path.join(__dirname, "../electron/pull"),
       {
         cwd: args.dir,
         env: {

--- a/packages/corvid-cli/src/electron/login.js
+++ b/packages/corvid-cli/src/electron/login.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+const { URL } = require("url");
+const { app, BrowserWindow } = require("electron");
+
+const mySitesUrl = "https://www.wix.com/account/sites";
+const signInHostname = "users.wix.com";
+
+app.on("ready", async () => {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 960,
+    show: false,
+    webPreferences: { nodeIntegration: false }
+  });
+
+  win.webContents.on("did-navigate", (event, url) => {
+    const parsed = new URL(url);
+    if (parsed.hostname === signInHostname) {
+      console.log(JSON.stringify({ event: "authenticatingUser" }));
+      win.show();
+    } else if (url === mySitesUrl) {
+      console.log(JSON.stringify({ event: "userAuthenticated" }));
+      win.hide();
+
+      win.webContents.session.cookies.get(
+        { url: "http://wix.com", name: "wixSession2" },
+        (error, cookies) => {
+          if (error) {
+            throw error;
+          }
+
+          console.log(
+            JSON.stringify({ msg: "authCookie", cookie: cookies[0] }, null, 2)
+          );
+        }
+      );
+      win.webContents.on("did-finish-load", () => app.quit());
+    }
+  });
+  win.loadURL(mySitesUrl);
+});

--- a/packages/corvid-cli/src/electron/logout.js
+++ b/packages/corvid-cli/src/electron/logout.js
@@ -1,0 +1,17 @@
+const { app, BrowserWindow } = require("electron");
+
+app.on("ready", async () => {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 960,
+    show: false,
+    webPreferences: { nodeIntegration: false }
+  });
+  await new Promise(resolve => {
+    win.webContents.session.clearStorageData(() => {
+      resolve();
+    });
+  });
+
+  win.close();
+});

--- a/packages/corvid-cli/src/electron/open-editor.js
+++ b/packages/corvid-cli/src/electron/open-editor.js
@@ -1,0 +1,22 @@
+const process = require("process");
+const { app } = require("electron");
+const { openWindow } = require("../utils/electron");
+const openEditorApp = require("../apps/open-editor");
+
+app.on("ready", async () => {
+  if (process.env.IGNORE_CERTIFICATE_ERRORS) {
+    app.on(
+      "certificate-error",
+      (event, webContents, url, error, certificate, callback) => {
+        // On certificate error we disable default behaviour (stop loading the page)
+        // and we then say "it is all fine - true" to the callback
+        event.preventDefault();
+        callback(true);
+      }
+    );
+  }
+
+  await openWindow(openEditorApp(), {
+    show: true && !process.env.CORVID_FORCE_HEADLESS
+  });
+});

--- a/packages/corvid-cli/src/electron/pull.js
+++ b/packages/corvid-cli/src/electron/pull.js
@@ -1,0 +1,22 @@
+const process = require("process");
+const { app } = require("electron");
+const yargs = require("yargs");
+const { openWindow } = require("../utils/electron");
+const pullApp = require("../apps/pull");
+
+app.on("ready", async () => {
+  if (process.env.IGNORE_CERTIFICATE_ERRORS) {
+    app.on(
+      "certificate-error",
+      (event, webContents, url, error, certificate, callback) => {
+        // On certificate error we disable default behaviour (stop loading the page)
+        // and we then say "it is all fine - true" to the callback
+        event.preventDefault();
+        callback(true);
+      }
+    );
+  }
+
+  const args = yargs.argv;
+  await openWindow(pullApp({ override: args.override, move: args.move }));
+});


### PR DESCRIPTION
Context:
Currently, corvid-cli is complicated and it is difficult to add new features/make changes to. It is also difficult to debug. The goal of this branch is to take steps towards improving it. I'd like to make changes in small chunks, and I believe this PR is a merge-able chunk.

Description:
This PR just separates the parts that run under `electron` from the parts that run in node. Currently, the same file is loaded in two different contexts, and each command mixes a few concerns: 
1. Exporting a yargs command descriptor, whose handler spawns an electron binary
2. The electron binary is given `__filename` to run against, so the same file is then run by electron

The PR moves (2) to a different file.