### PR TITLE
refactor(cli): move electron app communication to ipc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [0.2.8](https://github.com/wix-incubator/corvid/compare/v0.2.7...v0.2.8) (2020-04-01)
-
-**Note:** Version bump only for package corvid

--- a/packages/corvid-cli/CHANGELOG.md
+++ b/packages/corvid-cli/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [0.2.8](https://github.com/wix-incubator/corvid/compare/v0.2.7...v0.2.8) (2020-04-01)
-
-**Note:** Version bump only for package corvid-cli

--- a/packages/corvid-cli/package.json
+++ b/packages/corvid-cli/package.json
@@ -55,6 +55,7 @@
     "normalize-url": "^4.2.0",
     "opn": "^5.5.0",
     "ora": "3.4.0",
+    "serialize-error": "^6.0.0",
     "socket.io": "2.2.0",
     "socket.io-client": "^2.2.0",
     "update-notifier": "^3.0.0",

--- a/packages/corvid-cli/src/apps/open-editor.js
+++ b/packages/corvid-cli/src/apps/open-editor.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const process = require("process");
 const chalk = require("chalk");
-const logger = require("corvid-local-logger");
+const { logger, UserError } = require("corvid-local-logger");
 const genEditorUrl = require("../utils/genEditorUrl");
 const clientMessages = require("../utils/console-messages");
 const clientMessageActions = require("../utils/clientMessageActions");
@@ -21,14 +21,7 @@ const openEditorApp = ({ useSsl = true } = {}) => ({
       });
 
       client.on("parse-error", path => {
-        reject(
-          new Error(
-            JSON.stringify({
-              message: "Wix_File_Parse_Error",
-              params: { path }
-            })
-          )
-        );
+        reject(new UserError(getMessage("Wix_File_Parse_Error", { path })));
       });
 
       const {
@@ -74,15 +67,8 @@ const openEditorApp = ({ useSsl = true } = {}) => ({
             );
           },
           [clientMessages.DECODE_ERROR_MESSAGE]: path => {
-            reject(
-              new Error(
-                JSON.stringify({
-                  message: "Wix_File_Decode_Error",
-                  params: { path },
-                  type: "EditorError"
-                })
-              )
-            );
+            const errorMessage = getMessage("Wix_File_Decode_Error", { path });
+            reject(new EditorError(errorMessage, errorMessage));
           }
         })
       );

--- a/packages/corvid-cli/src/apps/pull.js
+++ b/packages/corvid-cli/src/apps/pull.js
@@ -16,7 +16,7 @@ const pullApp = ({ useSsl = true, override = false, move = false } = {}) => ({
     await new Promise(async (resolve, reject) => {
       // this event is not fired by the server yet
       client.on("clone-complete", () => {
-        console.log(JSON.stringify({ event: "projectDownloaded" }));
+        process.send({ event: "projectDownloaded" });
         resolve();
       });
 

--- a/packages/corvid-cli/src/commands/login.js
+++ b/packages/corvid-cli/src/commands/login.js
@@ -1,15 +1,12 @@
 const path = require("path");
 const chalk = require("chalk");
 const jwt = require("jsonwebtoken");
-const _ = require("lodash");
 const { launch } = require("../utils/electron");
 const createSpinner = require("../utils/spinner");
 const sessionData = require("../utils/sessionData");
 const getMessage = require("../messages");
 const { UserError } = require("corvid-local-logger");
 const commandWithDefaults = require("../utils/commandWithDefaults");
-const childProcess = require("child_process");
-const electron = require("electron");
 
 function parseSessionCookie(cookie) {
   try {
@@ -28,6 +25,7 @@ async function loginCommand(spinner, args = {}) {
   }
   spinner.start(chalk.grey(getMessage("Login_Command_Accessing")));
 
+  let authCookie = null;
   return launch(
     path.join(__dirname, "../electron/login"),
     {},
@@ -37,38 +35,20 @@ async function loginCommand(spinner, args = {}) {
       },
       userAuthenticated: () => {
         spinner.start(chalk.grey(getMessage("Login_Command_Authenticated")));
+      },
+      authCookie: cookie => {
+        authCookie = cookie;
+        sessionData.set({ uuid: parseSessionCookie(authCookie).userGuid });
       }
     },
     loginArgs
-  ).then(async messages => {
-    const cookieMessages = messages
-      ? messages.filter(({ msg }) => msg === "authCookie")
-      : [];
-    const authCookie = _.get(cookieMessages, [0, "cookie"]);
-    await sessionData.set({ uuid: parseSessionCookie(authCookie).userGuid });
-
-    return authCookie;
-  });
+  ).then(() => authCookie);
 }
 
 const storeCookies = ({ cookies }) =>
-  new Promise((resolve, reject) => {
-    const cp = childProcess.spawn(
-      electron,
-      [
-        path.join(__dirname, "../electron/store-cookies.js"),
-        `--cookies=${cookies}`
-      ],
-      {
-        stdio: ["inherit", "inherit", "inherit", "ipc"]
-      }
-    );
-    cp.on("exit", (code, signal) => {
-      code === 0 || (code === null && signal === "SIGTERM")
-        ? resolve()
-        : reject(code);
-    });
-  });
+  launch(path.join(__dirname, "../electron/store-cookies.js"), {}, {}, [
+    `--cookies=${cookies}`
+  ]);
 
 module.exports = commandWithDefaults({
   command: "login",

--- a/packages/corvid-cli/src/commands/pull.js
+++ b/packages/corvid-cli/src/commands/pull.js
@@ -40,7 +40,7 @@ async function pullCommand(spinner, args) {
         },
         error: error => {
           spinner.fail();
-          const errorMessage = getMessage(error);
+          const errorMessage = getMessage(error.message);
           if (errorMessage) {
             if (error === "CAN_NOT_PULL_NON_EMPTY_SITE") {
               reject(
@@ -54,7 +54,7 @@ async function pullCommand(spinner, args) {
               reject(new UserError(errorMessage));
             }
           } else {
-            reject(new Error(error));
+            reject(error);
           }
         }
       },

--- a/packages/corvid-cli/src/electron/login.js
+++ b/packages/corvid-cli/src/electron/login.js
@@ -12,10 +12,10 @@ app.on("ready", async () => {
   win.webContents.on("did-navigate", (event, url) => {
     const parsed = new URL(url);
     if (parsed.hostname === signInHostname) {
-      console.log(JSON.stringify({ event: "authenticatingUser" }));
+      process.send({ event: "authenticatingUser" });
       win.show();
     } else if (url === mySitesUrl) {
-      console.log(JSON.stringify({ event: "userAuthenticated" }));
+      process.send({ event: "userAuthenticated" });
       win.hide();
       win.webContents.session.cookies.get(
         { name: "wixSession2" },
@@ -23,9 +23,7 @@ app.on("ready", async () => {
           if (error) {
             throw error;
           }
-          console.log(
-            JSON.stringify({ msg: "authCookie", cookie: cookies[0] }, null, 2)
-          );
+          process.send({ event: "authCookie", payload: cookies[0] });
         }
       );
       win.webContents.on("did-finish-load", () => app.quit());

--- a/packages/corvid-cli/src/utils/EditorError.js
+++ b/packages/corvid-cli/src/utils/EditorError.js
@@ -7,4 +7,9 @@ class EditorError extends ExtendableError {
   }
 }
 
+const isEditorError = error =>
+  error instanceof EditorError ||
+  (error instanceof Error && error.name === "EditorError");
+
 module.exports = EditorError;
+module.exports.isEditorError = isEditorError;

--- a/packages/corvid-cli/src/utils/electron.js
+++ b/packages/corvid-cli/src/utils/electron.js
@@ -7,6 +7,8 @@ const client = require("socket.io-client");
 const electron = require("electron");
 const opn = require("opn");
 const get_ = require("lodash/get");
+const isObject_ = require("lodash/isObject");
+const isFunction_ = require("lodash/isFunction");
 const { serializeError, deserializeError } = require("serialize-error");
 const { logger } = require("corvid-local-logger");
 const { startInCloneMode, startInEditMode } = require("corvid-local-server");
@@ -60,18 +62,15 @@ function launch(file, options = {}, callbacks = {}, args = []) {
 
   return new Promise((resolve, reject) => {
     childElectronProcess.on("message", message => {
-      if (typeof message === "object") {
+      if (isObject_(message)) {
         if (message.event === "error") {
           const error = deserializeError(message.payload);
-          if (typeof callbacks.error === "function") {
+          if (isFunction_(callbacks.error)) {
             callbacks.error(error);
           } else {
             reject(error);
           }
-        } else if (
-          message.event &&
-          typeof callbacks[message.event] === "function"
-        ) {
+        } else if (message.event && isFunction_(callbacks[message.event])) {
           callbacks[message.event](message.payload);
         }
       }

--- a/packages/corvid-cli/src/utils/exitProcess.js
+++ b/packages/corvid-cli/src/utils/exitProcess.js
@@ -2,16 +2,16 @@ const chalk = require("chalk");
 const hasAnsi = require("has-ansi");
 const { killAllChildProcesses } = require("./electron");
 const { logger, UserError } = require("corvid-local-logger");
-const EditorError = require("./EditorError");
+const { isEditorError } = require("./EditorError");
 
 const colorRedIfNotYetColored = message =>
   message && hasAnsi(message) ? message : chalk.red(message);
 
 const exitWithError = async error => {
-  if (error instanceof UserError) {
+  if (UserError.isUserError(error)) {
     const coloredErrorMessage = colorRedIfNotYetColored(error.message);
     console.error(coloredErrorMessage); // eslint-disable-line no-console
-  } else if (error instanceof EditorError) {
+  } else if (isEditorError(error)) {
     logger.error(error);
     if (error.userMessage) {
       const coloredErrorMessage = colorRedIfNotYetColored(error.userMessage);

--- a/packages/corvid-dir-as-json/src/writeJsonToDir.js
+++ b/packages/corvid-dir-as-json/src/writeJsonToDir.js
@@ -1,7 +1,8 @@
 const fs = require("fs-extra");
 const path = require("path");
+const isObject_ = require("lodash/isObject");
 
-const isDirectoryJson = obj => typeof obj === "object";
+const isDirectoryJson = obj => isObject_(obj);
 
 const writeJsonToDir = async (dirPath, dirAsJson = {}) => {
   await fs.ensureDir(dirPath);

--- a/packages/corvid-e2e-tests/CHANGELOG.md
+++ b/packages/corvid-e2e-tests/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [0.2.8](https://github.com/wix-incubator/corvid/compare/v0.2.7...v0.2.8) (2020-04-01)
-
-**Note:** Version bump only for package corvid-e2e-tests

--- a/packages/corvid-local-logger/src/UserError.js
+++ b/packages/corvid-local-logger/src/UserError.js
@@ -6,7 +6,9 @@ class UserError extends ExtendableError {
   }
 }
 
-const isUserError = error => error instanceof UserError;
+const isUserError = error =>
+  error instanceof UserError ||
+  (error instanceof Error && error.name === "UserError");
 
 module.exports = UserError;
 module.exports.isUserError = isUserError;

--- a/packages/corvid-local-logger/src/initLogger.js
+++ b/packages/corvid-local-logger/src/initLogger.js
@@ -4,7 +4,7 @@ const defaults_ = require("lodash/defaults");
 const isError_ = require("lodash/isError");
 const initSentry = require("./sentry/initSentry");
 const SentryTransport = require("./sentry/SentryTransport");
-const UserError = require("./UserError");
+const { isUserError } = require("./UserError");
 
 const LOG_FILE_PATH = path.join(".corvid", "session.log");
 
@@ -26,7 +26,7 @@ const crashConsoleTransport = () =>
   new winston.transports.Console({
     level: "error",
     format: winston.format.printf(info =>
-      info.message instanceof UserError
+      isUserError(info.message)
         ? ""
         : `\n[corvid] an error has occured. see [${LOG_FILE_PATH}] for details.`
     )

--- a/packages/corvid-local-logger/src/sentry/SentryTransport.js
+++ b/packages/corvid-local-logger/src/sentry/SentryTransport.js
@@ -1,7 +1,7 @@
 const Sentry = require("@sentry/node");
 const Transport = require("winston-transport");
 const isError_ = require("lodash/isError");
-const UserError = require("../UserError");
+const { isUserError } = require("../UserError");
 
 const WINSTON_TO_SENTRY_LEVEL = {
   error: Sentry.Severity.Error,
@@ -53,7 +53,7 @@ class SentryTransport extends Transport {
 
     if (level === "error" || level === "warn") {
       if (isError_(message)) {
-        if (message instanceof UserError) {
+        if (isUserError(message)) {
           this._addBreadcrumb({
             message: message.message,
             category: "UserError",

--- a/packages/corvid-local-site/src/utils/ParseError.js
+++ b/packages/corvid-local-site/src/utils/ParseError.js
@@ -9,7 +9,9 @@ class ParseError extends ExtendableError {
   }
 }
 
-const isParseError = error => error instanceof ParseError;
+const isParseError = error =>
+  error instanceof ParseError ||
+  (error instanceof Error && error.name === "ParseError");
 
 module.exports = ParseError;
 module.exports.isParseError = isParseError;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8331,6 +8331,13 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+serialize-error@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-6.0.0.tgz#ccfb887a1dd1c48d6d52d7863b92544331fd752b"
+  integrity sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==
+  dependencies:
+    type-fest "^0.12.0"
+
 serve-static@1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
@@ -9172,6 +9179,11 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.12.0.tgz#f57a27ab81c68d136a51fd71467eff94157fa1ee"
+  integrity sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==
 
 type-fest@^0.3.0, type-fest@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
moving the communication between the main process and the electron script to "pic" instead of relying on console logs.
this creates a cleaner api and will allow us to use console logs for debuggning.