### PR TITLE
Fix a false positive logger warn

### DIFF
--- a/packages/corvid-cli/src/utils/electron.js
+++ b/packages/corvid-cli/src/utils/electron.js
@@ -182,7 +182,9 @@ async function openLocalEditorAndServer(app, windowOptions = {}) {
         )
         .then((result = {}) => {
           const getVersion = (url = "") => {
-            if (new URL(url).host === "localhost") {
+            if(!url) {
+              return "";
+            } else if (new URL(url).host === "localhost") {
               return "local";
             } else {
               return url.substring(url.lastIndexOf("/") + 1);


### PR DESCRIPTION
In corvid-cli, when one of the "santaBase" or "editorBase"
value of electron window was not available, none where added to the logger sessionData
and a cryptic warning showed up in console:
`error reading editor versions: Invalid Url:`

This will remove the warning in this particular case.
